### PR TITLE
CB-11405 Exit on wait error

### DIFF
--- a/operation/common.go
+++ b/operation/common.go
@@ -50,7 +50,7 @@ func wait(itemsChan chan []types.CloudItem, errChan chan error, errorMsg string)
 				exit = true
 				break
 			}
-			log.Errorf(errorMsg+", err: %s", err.Error())
+			log.Fatalf(errorMsg+", err: %s", err.Error())
 		}
 	}
 	return allItems


### PR DESCRIPTION
We have seen successful builds that should have been failed, so here is a fix for these
`time="2021-03-09T07:00:46+01:00" level=info msg="[GCP] Successfully prepared"
time="2021-03-09T07:00:47+01:00" level=error msg="[GCP] Failed to get creation timestamp of disk, err: [GCP] Failed to get CREATE operation for database instance"
time="2021-03-09T07:00:47+01:00" level=error msg="[GET_DATABASES] Failed to collect databases, err: [GCP] Failed to get CREATE operation for database instance"
Set build name.
New build name is '#91272 gcp-getDatabases-stop'
Notifying upstream projects of job completion
Finished: SUCCESS`