### PR TITLE
allow gcp app default credentials to pass through

### DIFF
--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -42,7 +42,7 @@ func init() {
 	applicationCredentials := os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")
 	if len(applicationCredentials) == 0 {
 		log.Warn("[GCP] GOOGLE_APPLICATION_CREDENTIALS environment variable is missing")
-		return
+                log.Warn("[GCP] Assuming Application Default Credentials are configured")
 	}
 	ctx.CloudProviders[types.GCP] = func() types.CloudProvider {
 		if len(provider.projectID) == 0 {


### PR DESCRIPTION
When run on a GCP instance, cloud-haunter does not allow Application Default Credentials [1] to succeed.

This alters the program flow to not return if the GOOGLE_APPLICATION_CREDENTIALS environment variable is unset.
Instead, a warning is printed to let the user know that the requested operation will fail unless they've already
configured ADC.

[1] https://cloud.google.com/docs/authentication/production#automatically
