### PR TITLE
CB-28588 Add new module to delete GCP database instances

### DIFF
--- a/action/termination.go
+++ b/action/termination.go
@@ -48,6 +48,8 @@ func (a terminationAction) Execute(op types.OpType, filters []types.FilterType, 
 					errors = deleteImages(provider, cloudItems)
 				case types.Alert:
 					errors = deleteAlerts(provider, cloudItems)
+				case types.Database:
+					errors = deleteDatabases(provider, cloudItems)
 				default:
 					panic(fmt.Sprintf("[TERMINATION] Operation on type %T is not allowed", t))
 				}
@@ -107,4 +109,13 @@ func deleteAlerts(provider types.CloudProvider, items []*types.CloudItem) []erro
 		alerts = append(alerts, &alert)
 	}
 	return provider.DeleteAlerts(types.NewAlertContainer(alerts))
+}
+
+func deleteDatabases(provider types.CloudProvider, items []*types.CloudItem) []error {
+	var databases []*types.Database
+	for _, item := range items {
+		database := (*item).GetItem().(types.Database)
+		databases = append(databases, &database)
+	}
+	return provider.DeleteDatabases(types.NewDatabaseContainer(databases))
 }

--- a/action/termination_test.go
+++ b/action/termination_test.go
@@ -47,6 +47,10 @@ func (p *mockProvider) GetDatabases() ([]*types.Database, error) {
 	return nil, nil
 }
 
+func (p *mockProvider) DeleteDatabases(databases *types.DatabaseContainer) []error {
+	return nil
+}
+
 func (p *mockProvider) GetDisks() ([]*types.Disk, error) {
 	return nil, nil
 }

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -218,6 +218,10 @@ func (p awsProvider) GetDatabases() ([]*types.Database, error) {
 	return getDatabases(p.GetCloudType(), rdsClients, ctClients)
 }
 
+func (p awsProvider) DeleteDatabases(databases *types.DatabaseContainer) []error {
+	return []error{errors.New("[AWS] Deleting databases is not supported yet")}
+}
+
 func (p awsProvider) GetDisks() ([]*types.Disk, error) {
 	log.Debug("[AWS] Fetch volumes")
 	ec2Clients, _ := p.getEc2AndCTClientsByRegion()

--- a/azure/azure.go
+++ b/azure/azure.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/compute/armcompute/v6"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/postgresql/armpostgresqlflexibleservers/v4"
@@ -479,6 +480,10 @@ func (p azureProvider) GetDatabases() ([]*types.Database, error) {
 	}
 
 	return databases, nil
+}
+
+func (p azureProvider) DeleteDatabases(databases *types.DatabaseContainer) []error {
+	return []error{errors.New("[AZURE] Deleting databases is not supported yet")}
 }
 
 func (p azureProvider) GetAlerts() ([]*types.Alert, error) {

--- a/gcp/gcp.go
+++ b/gcp/gcp.go
@@ -791,6 +791,43 @@ func (p gcpProvider) GetDatabases() ([]*types.Database, error) {
 	return p.getDatabases(aggregator)
 }
 
+func (p gcpProvider) DeleteDatabases(databases *types.DatabaseContainer) []error {
+	gcpDatabases := databases.Get(types.GCP)
+	log.Debugf("[GCP] Deleting databases: %v", gcpDatabases)
+
+	wg := sync.WaitGroup{}
+	wg.Add(len(gcpDatabases))
+	errChan := make(chan error)
+
+	for _, database := range gcpDatabases {
+
+		go func(database *types.Database) {
+			defer wg.Done()
+
+			if ctx.DryRun {
+				log.Infof("[GCP] Dry-run set, db is not deleted: %s", database.Name)
+			} else {
+				err := p.doAndPollSqlCall(p.sqlClient.Instances.Delete(p.projectID, database.Name))
+				if err != nil {
+					log.Errorf("[GCP] Failed to delete db %s, err: %s", database.Name, err)
+					errChan <- err
+				}
+			}
+		}(database)
+	}
+
+	go func() {
+		wg.Wait()
+		close(errChan)
+	}()
+
+	var errs []error
+	for err := range errChan {
+		errs = append(errs, err)
+	}
+	return errs
+}
+
 type instancesListAggregator interface {
 	Do(...googleapi.CallOption) (*compute.InstanceAggregatedList, error)
 }

--- a/operation/common_test.go
+++ b/operation/common_test.go
@@ -89,6 +89,10 @@ func (p dummyProvider) GetDatabases() ([]*types.Database, error) {
 	return nil, nil
 }
 
+func (p dummyProvider) DeleteDatabases(databases *types.DatabaseContainer) []error {
+	return nil
+}
+
 func (p dummyProvider) GetDisks() ([]*types.Disk, error) {
 	return nil, nil
 }

--- a/types/cloud.go
+++ b/types/cloud.go
@@ -35,6 +35,7 @@ type CloudProvider interface {
 	DeleteAlerts(*AlertContainer) []error
 	GetAccesses() ([]*Access, error)
 	GetDatabases() ([]*Database, error)
+	DeleteDatabases(*DatabaseContainer) []error
 	GetDisks() ([]*Disk, error)
 	DeleteDisks(*DiskContainer) []error
 	GetImages() ([]*Image, error)


### PR DESCRIPTION

### [CB-28588](https://jira.cloudera.com/browse/CB-28588)

Currently, databases are deleted as part of the terminateStacks operation. However, there is no explicit operation to delete orphaned databases individually. This PR introduces a new module for deleting database instances and implements support for the GCP provider.