### PR TITLE
CB-28590 - Cloud haunter does not clean up running QA instance

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1954,7 +1954,13 @@ func getNativeStacks(cloudType types.CloudType, ec2Clients map[string]ec2Client,
 				}
 
 				if instance.State != nativeStack.State {
-					nativeStack.State = types.Unknown
+					if instance.State == types.Running && nativeStack.State == types.Stopped {
+						nativeStack.State = types.Running
+					} else if instance.State == types.Stopped && nativeStack.State == types.Running {
+						nativeStack.State = types.Running
+					} else {
+						nativeStack.State = types.Unknown
+					}
 				}
 
 				if instance.Created.Before(nativeStack.Created) {


### PR DESCRIPTION
When terminating stacks if a stack has at least one instance that is not in running state (stopped, terminated, etc.) then the stack's status will be unknown. Currently, these stacks won't be deleted by Haunter. Therefore I refactored the stack state setter logic to mark a stack as 'running' if it has at least one running instance.
See more details [here](https://jira.cloudera.com/browse/CB-28590)