### PR TITLE
CB-29500 - Haunter cannot delete VPCs with dependencies correctly

### DIFF
--- a/aws/aws.go
+++ b/aws/aws.go
@@ -225,15 +225,11 @@ func (p awsProvider) GetResources() ([]*types.Resource, error) {
 	if vpcsErr != nil {
 		return nil, vpcsErr
 	}
-	subnets, subnetsErr := getSubnets(p.GetCloudType(), ec2Clients)
-	if subnetsErr != nil {
-		return nil, subnetsErr
-	}
 	lbs, lbsErr := getLoadBalancers(p.GetCloudType(), elbClients)
 	if lbsErr != nil {
 		return nil, lbsErr
 	}
-	resources := append(append(vpcs, subnets...), lbs...)
+	resources := append(vpcs, lbs...)
 	return resources, nil
 }
 
@@ -292,62 +288,6 @@ func getVpcs(cloudType types.CloudType, ec2Clients map[string]ec2Client) ([]*typ
 	}
 
 	return vpcs, nil
-}
-
-func getSubnets(cloudType types.CloudType, ec2Clients map[string]ec2Client) ([]*types.Resource, error) {
-	log.Debug("[AWS] Fetching subnets")
-	subnetChan := make(chan *types.Resource, 5)
-	wg := sync.WaitGroup{}
-	wg.Add(len(ec2Clients))
-
-	for r, c := range ec2Clients {
-		log.Debugf("[AWS] Fetching subnets from region: %s", r)
-		go func(region string, client ec2Client) {
-			defer wg.Done()
-			ec2Request := &ec2.DescribeSubnetsInput{}
-			for {
-				subnetsOutput, subnetsErr := client.DescribeSubnets(ec2Request)
-				if subnetsErr != nil {
-					log.Errorf("[AWS] Failed to fetch subnets in region %s, err: %s", region, subnetsErr)
-					return
-				} else {
-					for _, subnet := range subnetsOutput.Subnets {
-						tags := make(map[string]string)
-						for _, tag := range subnet.Tags {
-							tags[*tag.Key] = *tag.Value
-						}
-						newSubnet := &types.Resource{
-							ID:           *subnet.SubnetId,
-							Name:         tags["Name"],
-							CloudType:    cloudType,
-							Region:       region,
-							Tags:         tags,
-							Owner:        tags[ctx.OwnerLabel],
-							ResourceType: types.Subnet,
-						}
-						subnetChan <- newSubnet
-					}
-				}
-				if subnetsOutput.NextToken != nil {
-					ec2Request.SetNextToken(*subnetsOutput.NextToken)
-				} else {
-					break
-				}
-			}
-		}(r, c)
-	}
-
-	go func() {
-		wg.Wait()
-		close(subnetChan)
-	}()
-
-	var subnets []*types.Resource
-	for subnet := range subnetChan {
-		subnets = append(subnets, subnet)
-	}
-
-	return subnets, nil
 }
 
 func getLoadBalancers(cloudType types.CloudType, elbClients map[string]elbClient) ([]*types.Resource, error) {
@@ -596,9 +536,8 @@ func (p awsProvider) TerminateResources(resources *types.ResourceContainer) []er
 	elbClients := p.getElbClientsByRegion()
 	ec2Clients, _ := p.getEc2AndCTClientsByRegion()
 	deleteVpcsErr := deleteVpcs(ec2Clients, resources.Get(p.GetCloudType()))
-	deleteSubnetsErr := deleteSubnets(ec2Clients, resources.Get(p.GetCloudType()))
 	deleteLoadBalancersErr := deleteLoadBalancers(elbClients, resources.Get(p.GetCloudType()))
-	return append(append(deleteVpcsErr, deleteSubnetsErr...), deleteLoadBalancersErr...)
+	return append(deleteVpcsErr, deleteLoadBalancersErr...)
 }
 
 func deleteVpcs(ec2Clients map[string]ec2Client, resources []*types.Resource) []error {
@@ -620,61 +559,13 @@ func deleteVpcs(ec2Clients map[string]ec2Client, resources []*types.Resource) []
 				if ctx.DryRun {
 					log.Infof("[AWS] Dry-run set, VPC not deleted: %s in region: %s", vpc.ID, region)
 				} else {
-					_, err := ec2Client.DeleteVpc(&ec2.DeleteVpcInput{
-						VpcId: &vpc.ID,
-					})
+					err := deleteVpcWithDependencies(ec2Client, "N/A", vpc.ID, region)
 					if err != nil {
 						errChan <- err
-					} else {
-						log.Infof("[AWS] Deleting VPC: %s, region: %s", vpc.ID, region)
 					}
 				}
 			}
 		}(r, ec2Clients[r], v)
-	}
-
-	go func() {
-		wg.Wait()
-		close(errChan)
-	}()
-
-	var errs []error
-	for err := range errChan {
-		errs = append(errs, err)
-	}
-	return errs
-}
-
-func deleteSubnets(ec2Clients map[string]ec2Client, resources []*types.Resource) []error {
-	regionSubnets := map[string][]*types.Resource{}
-	for _, resource := range resources {
-		if resource.ResourceType == types.Subnet {
-			regionSubnets[resource.Region] = append(regionSubnets[resource.Region], resource)
-		}
-	}
-
-	wg := sync.WaitGroup{}
-	errChan := make(chan error)
-	wg.Add(len(regionSubnets))
-
-	for r, s := range regionSubnets {
-		go func(region string, ec2Client ec2Client, subnets []*types.Resource) {
-			defer wg.Done()
-			for _, subnet := range subnets {
-				if ctx.DryRun {
-					log.Infof("[AWS] Dry-run set, subnet not deleted: %s in region: %s", subnet.ID, region)
-				} else {
-					_, deleteErr := ec2Client.DeleteSubnet(&ec2.DeleteSubnetInput{
-						SubnetId: &subnet.ID,
-					})
-					if deleteErr != nil {
-						errChan <- deleteErr
-					} else {
-						log.Infof("[AWS] Deleting subnet: %s, region: %s", subnet.ID, region)
-					}
-				}
-			}
-		}(r, ec2Clients[r], s)
 	}
 
 	go func() {
@@ -1203,6 +1094,78 @@ func deleteVpcWithDependencies(ec2Client ec2Client, stackName string, vpcId stri
 		}
 	}
 
+	log.Infof("[AWS] Deleting internet gateways of VPC: %s in stack: %s, region: %s", vpcId, stackName, region)
+
+	attachmentVpcIdFilter := &ec2.Filter{}
+	attachmentVpcIdFilter.SetName("attachment.vpc-id")
+	attachmentVpcIdFilter.SetValues([]*string{&vpcId})
+	igws, err := ec2Client.DescribeInternetGateways(&ec2.DescribeInternetGatewaysInput{
+		Filters: []*ec2.Filter{attachmentVpcIdFilter},
+	})
+	if err != nil {
+		log.Errorf("[AWS] Failed to list internet gateways of VPC: %s in stack: %s, err: %s", vpcId, stackName, err)
+		return err
+	}
+
+	for _, igw := range igws.InternetGateways {
+		_, err = ec2Client.DetachInternetGateway(&ec2.DetachInternetGatewayInput{
+			InternetGatewayId: igw.InternetGatewayId,
+			VpcId:             &vpcId,
+		})
+		if err != nil {
+			log.Errorf("[AWS] Failed to detach internet gateway: %s in stack: %s, err: %s", *igw.InternetGatewayId, stackName, err)
+			return err
+		}
+
+		_, err = ec2Client.DeleteInternetGateway(&ec2.DeleteInternetGatewayInput{
+			InternetGatewayId: igw.InternetGatewayId,
+		})
+		if err != nil {
+			log.Errorf("[AWS] Failed to delete internet gateway: %s in stack: %s, err: %s", *igw.InternetGatewayId, stackName, err)
+			return err
+		}
+	}
+
+	log.Infof("[AWS] Deleting route tables of VPC: %s in stack: %s, region: %s", vpcId, stackName, region)
+
+	rts, err := ec2Client.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
+		Filters: []*ec2.Filter{vpcIdFilter},
+	})
+	if err != nil {
+		log.Errorf("[AWS] Failed to list route tables of VPC: %s in stack: %s, err: %s", vpcId, stackName, err)
+		return err
+	}
+
+	for _, rt := range rts.RouteTables {
+		isMain := false
+		for _, assoc := range rt.Associations {
+			if assoc.Main != nil && *assoc.Main {
+				isMain = true
+				break
+			}
+		}
+		if !isMain {
+			for _, assoc := range rt.Associations {
+				if assoc.RouteTableAssociationId != nil && (assoc.Main == nil || !*assoc.Main) {
+					_, err := ec2Client.DisassociateRouteTable(&ec2.DisassociateRouteTableInput{
+						AssociationId: assoc.RouteTableAssociationId,
+					})
+					if err != nil {
+						log.Errorf("[AWS] Failed to disassociate route table: %s in stack: %s, err: %s", *rt.RouteTableId, stackName, err)
+						return err
+					}
+				}
+			}
+			_, err := ec2Client.DeleteRouteTable(&ec2.DeleteRouteTableInput{
+				RouteTableId: rt.RouteTableId,
+			})
+			if err != nil {
+				log.Errorf("[AWS] Failed to delete route table: %s in stack: %s, err: %s", *rt.RouteTableId, stackName, err)
+				return err
+			}
+		}
+	}
+
 	log.Infof("[AWS] Deleting subnets of VPC: %s in stack: %s, region: %s", vpcId, stackName, region)
 
 	subnets, err := ec2Client.DescribeSubnets(&ec2.DescribeSubnetsInput{
@@ -1219,6 +1182,26 @@ func deleteVpcWithDependencies(ec2Client ec2Client, stackName string, vpcId stri
 		if err != nil {
 			log.Errorf("[AWS] Failed to delete subnet: %s in stack: %s, err: %s", *subnet.SubnetId, stackName, err)
 			return err
+		}
+	}
+
+	acls, err := ec2Client.DescribeNetworkAcls(&ec2.DescribeNetworkAclsInput{
+		Filters: []*ec2.Filter{vpcIdFilter},
+	})
+	if err != nil {
+		log.Errorf("[AWS] Failed to list network ACLs of VPC: %s in stack: %s, err: %s", vpcId, stackName, err)
+		return err
+	}
+
+	for _, acl := range acls.NetworkAcls {
+		if !*acl.IsDefault {
+			_, err := ec2Client.DeleteNetworkAcl(&ec2.DeleteNetworkAclInput{
+				NetworkAclId: acl.NetworkAclId,
+			})
+			if err != nil {
+				log.Errorf("[AWS] Failed to delete network ACL: %s in stack: %s, err: %s", *acl.NetworkAclId, stackName, err)
+				return err
+			}
 		}
 	}
 
@@ -1601,8 +1584,16 @@ type ec2Client interface {
 	DeleteVpc(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error)
 	DescribeSubnets(input *ec2.DescribeSubnetsInput) (*ec2.DescribeSubnetsOutput, error)
 	DeleteSubnet(input *ec2.DeleteSubnetInput) (*ec2.DeleteSubnetOutput, error)
+	DescribeInternetGateways(input *ec2.DescribeInternetGatewaysInput) (*ec2.DescribeInternetGatewaysOutput, error)
+	DetachInternetGateway(input *ec2.DetachInternetGatewayInput) (*ec2.DetachInternetGatewayOutput, error)
+	DeleteInternetGateway(input *ec2.DeleteInternetGatewayInput) (*ec2.DeleteInternetGatewayOutput, error)
+	DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error)
+	DeleteRouteTable(input *ec2.DeleteRouteTableInput) (*ec2.DeleteRouteTableOutput, error)
+	DescribeNetworkAcls(input *ec2.DescribeNetworkAclsInput) (*ec2.DescribeNetworkAclsOutput, error)
+	DeleteNetworkAcl(input *ec2.DeleteNetworkAclInput) (*ec2.DeleteNetworkAclOutput, error)
 	DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsInput) (*ec2.DescribeSecurityGroupsOutput, error)
 	DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error)
+	DisassociateRouteTable(input *ec2.DisassociateRouteTableInput) (*ec2.DisassociateRouteTableOutput, error)
 	TerminateInstances(input *ec2.TerminateInstancesInput) (*ec2.TerminateInstancesOutput, error)
 	WaitUntilInstanceTerminated(input *ec2.DescribeInstancesInput) error
 	DescribeAddresses(input *ec2.DescribeAddressesInput) (*ec2.DescribeAddressesOutput, error)
@@ -2732,6 +2723,14 @@ func getAlarmState(alarm cloudwatch.MetricAlarm) types.State {
 func getEc2Tags(ec2Tags []*ec2.Tag) types.Tags {
 	tags := make(types.Tags, 0)
 	for _, t := range ec2Tags {
+		tags[*t.Key] = *t.Value
+	}
+	return tags
+}
+
+func getElbTags(elbTags []*elb.Tag) types.Tags {
+	tags := make(types.Tags, 0)
+	for _, t := range elbTags {
 		tags[*t.Key] = *t.Value
 	}
 	return tags

--- a/aws/aws_test.go
+++ b/aws/aws_test.go
@@ -161,6 +161,139 @@ func TestNewStackOwner(t *testing.T) {
 	assert.Equal(t, "validOwner", stack.Owner)
 }
 
+func TestGetVpcs(t *testing.T) {
+	operationChannel := make(chan string)
+
+	ec2Clients := map[string]ec2Client{
+		"eu-central-1": mockEc2Client{operationChannel: operationChannel},
+	}
+
+	var resource *types.Resource
+
+	go func() {
+		defer close(operationChannel)
+
+		resources, err := getVpcs(types.AWS, ec2Clients)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(resources))
+		resource = resources[0]
+	}()
+
+	for range operationChannel {
+		// ignore
+	}
+
+	assert.Equal(t, "test-vpc-id", resource.ID)
+	assert.Equal(t, "test-vpc", resource.Name)
+	assert.Equal(t, types.AWS, resource.CloudType)
+	assert.Equal(t, getEc2Tags(getVpcTags()), resource.Tags)
+	assert.Equal(t, OWNER, resource.Owner)
+	assert.Equal(t, "eu-central-1", resource.Region)
+	assert.Equal(t, types.Vpc, resource.ResourceType)
+}
+
+func TestDeleteVpcs(t *testing.T) {
+	operationChannel := make(chan string)
+
+	ec2Clients := map[string]ec2Client{
+		"eu-central-1": mockEc2Client{operationChannel: operationChannel},
+	}
+	vpcs := []*types.Resource{
+		{
+			ID:           "test-vpc-id",
+			Name:         "test-vpc-name",
+			Tags:         getEc2Tags(getVpcTags()),
+			Owner:        OWNER,
+			CloudType:    types.AWS,
+			Region:       "eu-central-1",
+			ResourceType: types.Vpc,
+		},
+	}
+
+	go func() {
+		defer close(operationChannel)
+
+		deleteVpcs(ec2Clients, vpcs)
+	}()
+
+	assert.Equal(t, "DescribeVpcEndpoints", <-operationChannel)
+	assert.Equal(t, "DeleteVpcEndpoints:vpc-endpoint-id-1,vpc-endpoint-id-2", <-operationChannel)
+	assert.Equal(t, "DescribeInternetGateways", <-operationChannel)
+	assert.Equal(t, "DetachInternetGateway:igw1", <-operationChannel)
+	assert.Equal(t, "DeleteInternetGateway:igw1", <-operationChannel)
+	assert.Equal(t, "DescribeRouteTables", <-operationChannel)
+	assert.Equal(t, "DeleteRouteTable:routeTable1", <-operationChannel)
+	assert.Equal(t, "DescribeSubnets", <-operationChannel)
+	assert.Equal(t, "DeleteSubnet:subnet-id-1", <-operationChannel)
+	assert.Equal(t, "DeleteSubnet:subnet-id-2", <-operationChannel)
+	assert.Equal(t, "DescribeNetworkAcls", <-operationChannel)
+	assert.Equal(t, "DeleteNetworkAcl:networkAcl1", <-operationChannel)
+	assert.Equal(t, "DescribeSecurityGroups", <-operationChannel)
+	assert.Equal(t, "DeleteSecurityGroup:custom-group-id", <-operationChannel)
+	assert.Equal(t, "DeleteVpc:test-vpc-id", <-operationChannel)
+}
+
+func TestGetLoadBalancers(t *testing.T) {
+	operationChannel := make(chan string)
+
+	elbClients := map[string]elbClient{
+		"eu-central-1": mockElbClient{operationChannel: operationChannel},
+	}
+
+	var resource *types.Resource
+
+	go func() {
+		defer close(operationChannel)
+
+		resources, err := getLoadBalancers(types.AWS, elbClients)
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(resources))
+		resource = resources[0]
+	}()
+
+	for range operationChannel {
+		// ignore
+	}
+
+	assert.Equal(t, "lb-1", resource.ID)
+	assert.Equal(t, "lb-1-name", resource.Name)
+	assert.Equal(t, NOW, resource.Created)
+	assert.Equal(t, types.AWS, resource.CloudType)
+	assert.Equal(t, getElbTags(getResourceGroupedElbTags()), resource.Tags)
+	assert.Equal(t, OWNER, resource.Owner)
+	assert.Equal(t, "eu-central-1", resource.Region)
+	assert.Equal(t, types.LoadBalancer, resource.ResourceType)
+}
+
+func TestDeleteLoadBalancers(t *testing.T) {
+	operationChannel := make(chan string)
+
+	elbClients := map[string]elbClient{
+		"eu-central-1": mockElbClient{operationChannel: operationChannel},
+	}
+	lbs := []*types.Resource{
+		{
+			ID:           "lb-1",
+			Name:         "lb-1-name",
+			Created:      NOW,
+			Tags:         getElbTags(getResourceGroupedElbTags()),
+			Owner:        OWNER,
+			CloudType:    types.AWS,
+			Region:       "eu-central-1",
+			ResourceType: types.LoadBalancer,
+		},
+	}
+
+	go func() {
+		defer close(operationChannel)
+
+		deleteLoadBalancers(elbClients, lbs)
+	}()
+
+	assert.Equal(t, "ModifyLoadBalancerAttributes:lb-1", <-operationChannel)
+	assert.Equal(t, "DeleteLoadBalancer:lb-1", <-operationChannel)
+}
+
 func TestRemoveCfStack(t *testing.T) {
 	operationChannel := make(chan string)
 
@@ -200,12 +333,19 @@ func TestRemoveCfStack(t *testing.T) {
 	assert.Equal(t, "ModifyDBInstance", <-operationChannel)
 	assert.Equal(t, "DescribeVpcEndpoints", <-operationChannel)
 	assert.Equal(t, "DeleteVpcEndpoints:vpc-endpoint-id-1,vpc-endpoint-id-2", <-operationChannel)
+	assert.Equal(t, "DescribeInternetGateways", <-operationChannel)
+	assert.Equal(t, "DetachInternetGateway:igw1", <-operationChannel)
+	assert.Equal(t, "DeleteInternetGateway:igw1", <-operationChannel)
+	assert.Equal(t, "DescribeRouteTables", <-operationChannel)
+	assert.Equal(t, "DeleteRouteTable:routeTable1", <-operationChannel)
 	assert.Equal(t, "DescribeSubnets", <-operationChannel)
 	assert.Equal(t, "DeleteSubnet:subnet-id-1", <-operationChannel)
 	assert.Equal(t, "DeleteSubnet:subnet-id-2", <-operationChannel)
+	assert.Equal(t, "DescribeNetworkAcls", <-operationChannel)
+	assert.Equal(t, "DeleteNetworkAcl:networkAcl1", <-operationChannel)
 	assert.Equal(t, "DescribeSecurityGroups", <-operationChannel)
 	assert.Equal(t, "DeleteSecurityGroup:custom-group-id", <-operationChannel)
-	assert.Equal(t, "DeleteVpc", <-operationChannel)
+	assert.Equal(t, "DeleteVpc:vpc-id", <-operationChannel)
 	assert.Equal(t, "ModifyLoadBalancerAttributes:elb-arn", <-operationChannel)
 	assert.Equal(t, "DeleteLoadBalancer:elb-arn", <-operationChannel)
 	assert.Equal(t, "DeleteStack", <-operationChannel)
@@ -364,15 +504,66 @@ func (t mockEc2Client) DeleteVolume(input *ec2.DeleteVolumeInput) (*ec2.DeleteVo
 	return nil, nil
 }
 
+func (t mockEc2Client) DetachInternetGateway(input *ec2.DetachInternetGatewayInput) (*ec2.DetachInternetGatewayOutput, error) {
+	t.operationChannel <- "DetachInternetGateway:" + *input.InternetGatewayId
+	return nil, nil
+}
+
 func (t mockEc2Client) DetachVolume(input *ec2.DetachVolumeInput) (*ec2.VolumeAttachment, error) {
 	t.operationChannel <- "DetachVolume"
 	return nil, nil
+}
+
+func (t mockEc2Client) DescribeVpcs(input *ec2.DescribeVpcsInput) (*ec2.DescribeVpcsOutput, error) {
+	t.operationChannel <- "DescribeVpcs"
+	return &ec2.DescribeVpcsOutput{
+		Vpcs: []*ec2.Vpc{
+			{
+				VpcId: aws.String("test-vpc-id"),
+				Tags:  getVpcTags(),
+			},
+		},
+	}, nil
 }
 
 func (t mockEc2Client) DeregisterImage(input *ec2.DeregisterImageInput) (*ec2.DeregisterImageOutput, error) {
 	t.operationChannel <- "DeregisterImage"
 	t.deregisterImagesChannel <- *input.ImageId
 	return nil, nil
+}
+
+func (t mockEc2Client) DescribeInternetGateways(input *ec2.DescribeInternetGatewaysInput) (*ec2.DescribeInternetGatewaysOutput, error) {
+	t.operationChannel <- "DescribeInternetGateways"
+	return &ec2.DescribeInternetGatewaysOutput{
+		InternetGateways: []*ec2.InternetGateway{
+			{
+				InternetGatewayId: &(&types.S{S: "igw1"}).S,
+			},
+		},
+	}, nil
+}
+
+func (t mockEc2Client) DescribeNetworkAcls(input *ec2.DescribeNetworkAclsInput) (*ec2.DescribeNetworkAclsOutput, error) {
+	t.operationChannel <- "DescribeNetworkAcls"
+	return &ec2.DescribeNetworkAclsOutput{
+		NetworkAcls: []*ec2.NetworkAcl{
+			{
+				NetworkAclId: &(&types.S{S: "networkAcl1"}).S,
+				IsDefault:    aws.Bool(false),
+			},
+		},
+	}, nil
+}
+
+func (t mockEc2Client) DescribeRouteTables(input *ec2.DescribeRouteTablesInput) (*ec2.DescribeRouteTablesOutput, error) {
+	t.operationChannel <- "DescribeRouteTables"
+	return &ec2.DescribeRouteTablesOutput{
+		RouteTables: []*ec2.RouteTable{
+			{
+				RouteTableId: &(&types.S{S: "routeTable1"}).S,
+			},
+		},
+	}, nil
 }
 
 func (t mockEc2Client) DescribeVpcEndpoints(input *ec2.DescribeVpcEndpointsInput) (*ec2.DescribeVpcEndpointsOutput, error) {
@@ -399,7 +590,22 @@ func (t mockEc2Client) DeleteVpcEndpoints(input *ec2.DeleteVpcEndpointsInput) (*
 }
 
 func (t mockEc2Client) DeleteVpc(input *ec2.DeleteVpcInput) (*ec2.DeleteVpcOutput, error) {
-	t.operationChannel <- "DeleteVpc"
+	t.operationChannel <- "DeleteVpc:" + *input.VpcId
+	return nil, nil
+}
+
+func (t mockEc2Client) DeleteInternetGateway(input *ec2.DeleteInternetGatewayInput) (*ec2.DeleteInternetGatewayOutput, error) {
+	t.operationChannel <- "DeleteInternetGateway:" + *input.InternetGatewayId
+	return nil, nil
+}
+
+func (t mockEc2Client) DeleteNetworkAcl(input *ec2.DeleteNetworkAclInput) (*ec2.DeleteNetworkAclOutput, error) {
+	t.operationChannel <- "DeleteNetworkAcl:" + *input.NetworkAclId
+	return nil, nil
+}
+
+func (t mockEc2Client) DeleteRouteTable(input *ec2.DeleteRouteTableInput) (*ec2.DeleteRouteTableOutput, error) {
+	t.operationChannel <- "DeleteRouteTable:" + *input.RouteTableId
 	return nil, nil
 }
 
@@ -442,6 +648,11 @@ func (t mockEc2Client) DescribeSecurityGroups(input *ec2.DescribeSecurityGroupsI
 
 func (t mockEc2Client) DeleteSecurityGroup(input *ec2.DeleteSecurityGroupInput) (*ec2.DeleteSecurityGroupOutput, error) {
 	t.operationChannel <- "DeleteSecurityGroup:" + *input.GroupId
+	return nil, nil
+}
+
+func (t mockEc2Client) DisassociateRouteTable(input *ec2.DisassociateRouteTableInput) (*ec2.DisassociateRouteTableOutput, error) {
+	t.operationChannel <- "DisassociateRouteTable:" + *input.AssociationId
 	return nil, nil
 }
 
@@ -620,7 +831,9 @@ func (t mockElbClient) DescribeLoadBalancers(input *elb.DescribeLoadBalancersInp
 	return &elb.DescribeLoadBalancersOutput{
 		LoadBalancers: []*elb.LoadBalancer{
 			{
-				LoadBalancerArn: aws.String("lb-1"),
+				LoadBalancerArn:  aws.String("lb-1"),
+				LoadBalancerName: aws.String("lb-1-name"),
+				CreatedTime:      &NOW,
 			},
 		},
 	}, nil
@@ -680,6 +893,10 @@ func getResourceGroupedElbTags() []*elb.Tag {
 			Key:   aws.String(ctx.ResourceGroupingLabel),
 			Value: aws.String(RESOURCE_GROUPING_TAG_VALUE),
 		},
+		{
+			Key:   aws.String(ctx.OwnerLabel),
+			Value: aws.String(OWNER),
+		},
 	}
 }
 
@@ -692,6 +909,23 @@ func getResourceGroupedEc2Tags() []*ec2.Tag {
 		{
 			Key:   aws.String(ctx.OwnerLabel),
 			Value: aws.String(OWNER),
+		},
+	}
+}
+
+func getVpcTags() []*ec2.Tag {
+	return []*ec2.Tag{
+		{
+			Key:   aws.String(ctx.ResourceGroupingLabel),
+			Value: aws.String(RESOURCE_GROUPING_TAG_VALUE),
+		},
+		{
+			Key:   aws.String(ctx.OwnerLabel),
+			Value: aws.String(OWNER),
+		},
+		{
+			Key:   aws.String("Name"),
+			Value: aws.String("test-vpc"),
 		},
 	}
 }

--- a/types/resource.go
+++ b/types/resource.go
@@ -11,7 +11,6 @@ func (rt ResourceType) String() string {
 const (
 	LoadBalancer = ResourceType("LoadBalancer")
 	Vpc          = ResourceType("Vpc")
-	Subnet       = ResourceType("Subnet")
 )
 
 type ResourceContainer struct {


### PR DESCRIPTION
Currently, Haunter cannot delete VPCs having particular dependencies (route tables, internet gateways, etc.) This problem needs to be addressed.