### PR TITLE
CB-33277 Removed temporary flag -awsignore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ export BINARY=ch
 
 # This version refers to the next release version required,
 # which will be increased automatically by the dedicated release job
-export VERSION=0.5.73
+export VERSION=0.5.74
 
 ifeq ($(GH_PRE_RELEASE),true)
 	OLD_VER:=$(VERSION)

--- a/aws/aws.go
+++ b/aws/aws.go
@@ -1839,15 +1839,7 @@ func getCFStacks(cloudType types.CloudType, cfClients map[string]cfClient) ([]*t
 				log.Debugf("[AWS] Processing stacks (%d) in region: %s: [%s]", len(stackResult.Stacks), region, stackResult.Stacks)
 				for _, s := range stackResult.Stacks {
 					stack := newStack(cloudType, s, region)
-					if ctx.WorkaroundAwsIgnoreStack {
-						if !strings.HasPrefix(stack.Name, "StackSet-") {
-							cfChan <- stack
-						} else {
-							log.Infof("Ignoring stackset %s", stack.Name)
-						}
-					} else {
-						cfChan <- stack
-					}
+					cfChan <- stack
 				}
 				if stackResult.NextToken != nil {
 					nextToken = *stackResult.NextToken

--- a/context/context.go
+++ b/context/context.go
@@ -44,8 +44,6 @@ var IgnoreLabelDisabled = false
 // ExactMatchOwner is a global flag for 'exact match' or 'starts with' matching of owner
 var ExactMatchOwner = false
 
-var WorkaroundAwsIgnoreStack = false
-
 var AwsExcludedRegions = make(map[string]bool)
 
 // Operations contains all the available operations

--- a/main.go
+++ b/main.go
@@ -39,7 +39,6 @@ func main() {
 	verbose := flag.Bool("v", false, "verbose")
 	ignoreLabelDisabled := flag.Bool("i", false, "disable ignore label")
 	exactMatchOwner := flag.Bool("e", false, "exact match owner")
-	workaroundAWsIgnoreStack := flag.Bool("awsignore", false, "AWS stack ignore workaround")
 	excludedAwsRegions := flag.String("excludeAwsRegion", "", "comma separated list of AWS regions to exclude")
 
 	flag.Parse()
@@ -58,7 +57,6 @@ func main() {
 	}
 	ctx.IgnoreLabelDisabled = *ignoreLabelDisabled
 	ctx.ExactMatchOwner = *exactMatchOwner
-	ctx.WorkaroundAwsIgnoreStack = *workaroundAWsIgnoreStack
 
 	if filterConfigLoc != nil && len(*filterConfigLoc) != 0 {
 		var err error

--- a/main.go
+++ b/main.go
@@ -123,7 +123,7 @@ func main() {
 		items = filter.Execute(items)
 	}
 	action.Execute(*op, filterNames, items)
-	println("All operations completed.")
+	log.Info("Action completed.")
 }
 
 // should be kept in sync with README.md


### PR DESCRIPTION
Removed temporary flag `-awsignore` used to ignore stacksets, but they are no longer needed as proper owner tags were set up in our internal systems, so this was a Cloudera specific use case.